### PR TITLE
fix: Unresolved attribute (path.dirname) - RizomUVWinRegisterInstallPath

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,8 @@ On Windows platform the location of the last RizomUV installation directory can 
                 try:
                     key = winreg.OpenKey(winreg.HKEY_LOCAL_MACHINE, path)
                     exePath = winreg.QueryValue(key, "rizomuv.exe")
-                    return path.dirname(exePath)
-                except:
+                    return os.path.dirname(exePath)
+                except FileNotFoundError:
                     pass
 
         return None

--- a/RizomUVLink.py
+++ b/RizomUVLink.py
@@ -113,8 +113,8 @@ class CRizomUVLink(CRizomUVLinkBase):
                 try:
                     key = winreg.OpenKey(winreg.HKEY_LOCAL_MACHINE, path)
                     exePath = winreg.QueryValue(key, "rizomuv.exe")
-                    return path.dirname(exePath)
-                except:
+                    return os.path.dirname(exePath)
+                except FileNotFoundError:
                     pass
 
         return None


### PR DESCRIPTION
path.dirname is an unresolved attribute. 

I also changed the bare except clause to FileNotFound as it was masking the problem and causing the function to always return None even though the registry key exists.

Also updated the readme to reflect my changes.