### PR TITLE
refactor: simplify python version detection

### DIFF
--- a/win/__init__.py
+++ b/win/__init__.py
@@ -1,17 +1,17 @@
 # MIT License
-# 
+#
 # Copyright (c) 2022 Rizom-Lab
-# 
+#
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
 # in the Software without restriction, including without limitation the rights
 # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 # copies of the Software, and to permit persons to whom the Software is
 # furnished to do so, subject to the following conditions:
-# 
+#
 # The above copyright notice and this permission notice shall be included in all
 # copies or substantial portions of the Software.
-# 
+#
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -20,30 +20,16 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-# Trying python versions from the oldest to the newest
-try:
-	import win.rizomuvlink_python36 as rizomuvlink
-except:
-	try:
-		import win.rizomuvlink_python37 as rizomuvlink
-	except:
-		try:
-			import win.rizomuvlink_python38 as rizomuvlink
-		except:
-			try:
-				import win.rizomuvlink_python39 as rizomuvlink
-			except:
-				try:
-					import win.rizomuvlink_python310 as rizomuvlink
-				except:
-					try:
-						import win.rizomuvlink_python311 as rizomuvlink
-					except:
-						try:
-							import win.rizomuvlink_python312 as rizomuvlink
-						except:
-							try:
-								import win.rizomuvlink_python313 as rizomuvlink
-							except:
-								raise "rizomuvlink version for the current python version not found. Please tell to the Rizom-Lab team which version would you need. We may add it to the list."
+import importlib
+import sys
 
+major, minor = sys.version_info[:2]
+module_name = f"win.rizomuvlink_python{major}{minor}"
+
+try:
+    rizomuvlink = importlib.import_module(module_name)
+except ImportError as e:
+    raise ImportError(
+        f"No rizomuvlink build for Python {major}.{minor}. "
+        f"Please tell the Rizom-Lab team which version you need. We may add it to the list."
+    ) from e


### PR DESCRIPTION
Replaces the exception chain with dynamic version detection using importlib.

- Removes the need to extend the chain with new versions.
- Cleaner console output when the exception is thrown.

Works with Python 3.6+.